### PR TITLE
ensure py3.10 in tests

### DIFF
--- a/.github/workflows/ci-cron-tests.yml
+++ b/.github/workflows/ci-cron-tests.yml
@@ -20,15 +20,15 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, macos-latest] # TODO: re-enable windows-latest
-        python: [3.8, 3.9, 3.10]
+        python: ['3.8', '3.9', '3.10']
         include:
           - python: '3.10'
             toxenv: py310-test-cov
 
-          - python: 3.9
+          - python: '3.9'
             toxenv: py39-test-cov
 
-          - python: 3.8
+          - python: '3.8'
             toxenv: py38-test-alldeps
 
     steps:

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -112,9 +112,9 @@ jobs:
             docs/libs/core
 
       - name: Run tests - core
+        if: steps.changed-files-infrastructure.outputs.any_modified || steps.changed-files-core.outputs.any_modified == 'true'
         working-directory: ./libs/core
         run: tox ${{ matrix.toxargs }} -c ../../tests/tox.ini -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}
-        if: steps.changed-files-infrastructure.outputs.any_modified || steps.changed-files-core.outputs.any_modified == 'true'
 
       # ------------------
 
@@ -123,6 +123,3 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           file: ./coverage.xml
-
-# TODO!
-# parallel_and_32bit:


### PR DESCRIPTION
Signed-off-by: nstarman <nstarkman@protonmail.com>

## Description

Fix py3.1 instead of py3.10

## PR Checklist

- [ ] Check out the [contributing guidelines](https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md)
- [ ] Check out the [contributing workflow](http://docs.astropy.org/en/latest/development/workflow/development_workflow.html) ( for a practical example [click here](https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example) )
- [ ] Give a detailed description of the PR above.
- [ ] Document changes in the `CHANGES.rst` file. See existing changelog for examples.
- [ ] Add tests, if applicable, to ensure code coverage never decreases.
- [ ] Make sure the docs are up to date, if applicable, particularly the docstrings and RST files in `docs` folder.
- [ ] Ensure linear history by rebasing, when requested by the maintainer.
